### PR TITLE
WIP: Add quick toggle emulation

### DIFF
--- a/plugin/source/main.cpp
+++ b/plugin/source/main.cpp
@@ -162,6 +162,12 @@ static void quickSelectComboCallback(ConfigItemButtonCombo* item, uint32_t newVa
     WUPS_StoreInt(nullptr, "quickSelectCombo", (int32_t) currentQuickSelectCombination);
 }
 
+static void quickRemoveComboCallback(ConfigItemButtonCombo* item, uint32_t newValue)
+{
+    currentQuickRemoveCombination = newValue;
+    WUPS_StoreInt(nullptr, "quickRemoveCombo", (int32_t) currentQuickRemoteCombination);
+}
+
 WUPS_GET_CONFIG()
 {
     if (WUPS_OpenStorage() != WUPS_STORAGE_ERROR_SUCCESS) {
@@ -212,6 +218,8 @@ WUPS_GET_CONFIG()
     WUPSConfigItemBoolean_AddToCategoryHandled(config, cat, "favorites_per_title", "Per-Title Favorites", favoritesPerTitle, favoritesPerTitleCallback);
 
     WUPSConfigItemButtonCombo_AddToCategoryHandled(config, cat, "quick_select_combination", "Quick Select Combo", currentQuickSelectCombination, quickSelectComboCallback);
+
+    WUPSConfigItemButtonCombo_AddToCategoryHandled(config, cat, "quick_remove_combination", "Quick Remove Combo", currentQuickRemoveCombination, quickRemoveComboCallback);
 
     ConfigItemDumpAmiibo_AddToCategoryHandled(config, cat, "dump_amiibo", "Dump Amiibo", (TAG_EMULATION_PATH + "dumps").c_str());
 

--- a/plugin/source/quick_select.cpp
+++ b/plugin/source/quick_select.cpp
@@ -40,6 +40,23 @@ static void cycleQuickSelect()
     }
 }
 
+
+static void toggleEmulation()
+{
+    NfpiiEmulationState state = NfpiiGetEmulationState();
+    if (state == NFPII_EMULATION_ON) {
+        NfpiiSetEmulationState(NFPII_EMULATION_OFF);
+        std::string notifText = "re_nfpii: Disabled emulation";
+    } else {
+        NfpiiSetEmulationState(NFPII_EMULATION_ON);
+        std::string notifText = "re_nfpii: Enabled emulation";
+    };
+
+    if (NotificationModule_InitLibrary() == NOTIFICATION_MODULE_RESULT_SUCCESS) {
+        NotificationModule_AddInfoNotification(notifText.c_str());
+    }
+}
+
 DECL_FUNCTION(int32_t, VPADRead, VPADChan chan, VPADStatus* buffer, uint32_t buffer_size, VPADReadError* error)
 {
     VPADReadError real_error;


### PR DESCRIPTION
Like the quick select hotkey, but it removes the amiibo. This should make playing games like Mario Party 10 easier, also it's just generally more convenient