### PR TITLE
Display error if plugin is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ghcr.io/wiiu-env/devkitppc:20230621
 
-COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20230719 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20250208 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:20230719 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libnotifications:20230621 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/libnotifications:20240426 /artifacts $DEVKITPRO
 
 RUN \
 mkdir wut && \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ CFLAGS	+=	-std=gnu11
 ASFLAGS	:=	$(ARCH)
 LDFLAGS	=	$(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map) $(WUMSSPECS) 
 
-LIBS	:=	-lwums -lwut
+LIBS	:=	-lwums -lwut -lnotifications
 
 #-------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level

--- a/include/nfpii.h
+++ b/include/nfpii.h
@@ -52,6 +52,8 @@ NFCError NfpiiQueueNFCGetTagInfo(NFCGetTagInfoCallbackFn callback, void* arg);
 
 void NfpiiSetLogHandler(NfpiiLogHandler handler);
 
+void NfpiiSetPluginloaded();
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugin/Makefile
+++ b/plugin/Makefile
@@ -110,7 +110,7 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 all: $(BUILD)
 
 $(BUILD):
-	@[ -d $@ ] || mkdir -p $@
+	@$(shell [ ! -d $(BUILD) ] && mkdir -p $(BUILD))
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 #-------------------------------------------------------------------------------

--- a/plugin/source/main.cpp
+++ b/plugin/source/main.cpp
@@ -126,6 +126,8 @@ ON_APPLICATION_START()
     } else {
         DEBUG_FUNCTION_LINE("Failed to open storage");
     }
+
+    NfpiiSetPluginloaded();
 }
 
 static void stateChangedCallback(ConfigItemMultipleValues* values, uint32_t index)

--- a/plugin/source/nn_nfp.def
+++ b/plugin/source/nn_nfp.def
@@ -13,6 +13,7 @@ NfpiiSetTagEmulationPath
 NfpiiGetTagEmulationPath
 NfpiiQueueNFCGetTagInfo
 NfpiiSetLogHandler
+NfpiiSetPluginloaded
 
 // nn_nfp exports
 AntennaCheck__Q2_2nn3nfpFv

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -7,8 +7,11 @@
 
 #include <nfpii.h>
 #include <re_nfpii/re_nfpii.hpp>
+#include <notifications/notifications.h>
 
 #include "utils/LogHandler.hpp"
+
+#include <string_view>
 
 #define STR_VALUE(arg) #arg
 #define VERSION_STRING(x, y, z) "v" STR_VALUE(x) "." STR_VALUE(y) "." STR_VALUE(z)
@@ -19,11 +22,33 @@ WUMS_MODULE_AUTHOR("GaryOderNichts");
 WUMS_MODULE_VERSION(VERSION_STRING(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH));
 WUMS_MODULE_LICENSE("GPLv2");
 
+namespace  {
+    static bool sIsPluginLoaded = false;
+    static bool sIsPluginLoadedInfoShown = false;
+
+    void ShowNotification(std::string_view notification) {
+        auto err1 = NotificationModule_SetDefaultValue(NOTIFICATION_MODULE_NOTIFICATION_TYPE_INFO,
+                                                       NOTIFICATION_MODULE_DEFAULT_OPTION_KEEP_UNTIL_SHOWN, true);
+        auto err2 = NotificationModule_SetDefaultValue(NOTIFICATION_MODULE_NOTIFICATION_TYPE_INFO,
+                                                       NOTIFICATION_MODULE_DEFAULT_OPTION_DURATION_BEFORE_FADE_OUT,
+                                                       15.0f);
+
+        if (err1 != NOTIFICATION_MODULE_RESULT_SUCCESS || err2 != NOTIFICATION_MODULE_RESULT_SUCCESS) return;
+
+        NotificationModule_AddInfoNotification(notification.data());
+    }
+
+}
+
 WUMS_INITIALIZE(myargs)
 {
     if (!WHBLogModuleInit()) {
         WHBLogCafeInit();
         WHBLogUdpInit();
+    }
+
+    if (NotificationModule_InitLibrary() != NOTIFICATION_MODULE_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE("NotificationModule_InitLibrary failed");
     }
 
     LogHandler::Init();
@@ -35,12 +60,20 @@ WUMS_APPLICATION_STARTS()
         WHBLogCafeInit();
         WHBLogUdpInit();
     }
+    sIsPluginLoaded = false;
 }
 
 WUMS_APPLICATION_ENDS()
 {
     // Call finalize in case the application doesn't
     re::nfpii::tagManager.Finalize();
+}
+
+WUMS_ALL_APPLICATION_STARTS_DONE() {
+    if(!sIsPluginLoadedInfoShown && !sIsPluginLoaded) {
+        ShowNotification("re_nfpii module is loaded but the companion plugin is not loaded");
+        sIsPluginLoadedInfoShown = true;
+    }
 }
 
 uint32_t NfpiiGetVersion(void)
@@ -104,6 +137,11 @@ NFCError NfpiiQueueNFCGetTagInfo(NFCGetTagInfoCallbackFn callback, void* arg)
     return re::nfpii::tagManager.QueueNFCGetTagInfo(callback, arg);
 }
 
+void NfpiiSetPluginloaded()
+{
+    sIsPluginLoaded = true;
+}
+
 WUMS_EXPORT_FUNCTION(NfpiiIsInitialized);
 WUMS_EXPORT_FUNCTION(NfpiiSetEmulationState);
 WUMS_EXPORT_FUNCTION(NfpiiGetEmulationState);
@@ -113,3 +151,4 @@ WUMS_EXPORT_FUNCTION(NfpiiSetRemoveAfterSeconds);
 WUMS_EXPORT_FUNCTION(NfpiiSetTagEmulationPath);
 WUMS_EXPORT_FUNCTION(NfpiiGetTagEmulationPath);
 WUMS_EXPORT_FUNCTION(NfpiiQueueNFCGetTagInfo);
+WUMS_EXPORT_FUNCTION(NfpiiSetPluginloaded);


### PR DESCRIPTION
The upcoming Aroma release will allow the user to unload a plugin from the config menu. This PR adds a basic notification to inform the user that the module is still running but the plugin is missing (if missing)

For testing you need to use the [WUMSLoader nightly](https://github.com/wiiu-env/WUMSLoader/releases/tag/WUMSLoader-20250208-134020) and [AromaBaseModule nightly](https://github.com/wiiu-env/AromaBaseModule/releases/tag/AromaBaseModule-20250208-133206) and build the module with latest WUMS 0.3.3